### PR TITLE
Optimization to reduce write load to ZK

### DIFF
--- a/drove-executor/src/main/java/com/phonepe/drove/executor/ExecutorOptions.java
+++ b/drove-executor/src/main/java/com/phonepe/drove/executor/ExecutorOptions.java
@@ -16,6 +16,7 @@
 
 package com.phonepe.drove.executor;
 
+import com.phonepe.drove.executor.discovery.RemoteUpdateMode;
 import com.phonepe.drove.models.application.nonroot.UserSpec;
 import io.dropwizard.util.DataSize;
 import io.dropwizard.util.DataSizeUnit;
@@ -49,6 +50,7 @@ public class ExecutorOptions {
     public static final Duration DEFAULT_CONTAINER_COMMAND_TIMEOUT = Duration.seconds(30);
     @SuppressWarnings("java:S1075")
     public static final String DEFAULT_DOCKER_SOCKET_PATH = "/var/run/docker.sock";
+    public static final RemoteUpdateMode DEFAULT_UPDATE_MODE = RemoteUpdateMode.RPC;
 
     public static final ExecutorOptions DEFAULT = new ExecutorOptions(null,
                                                                       true,
@@ -58,7 +60,8 @@ public class ExecutorOptions {
                                                                       DEFAULT_LOG_CACHE_COUNT,
                                                                       DEFAULT_CONTAINER_COMMAND_TIMEOUT,
                                                                       DEFAULT_DOCKER_SOCKET_PATH,
-                                                                      null);
+                                                                      null,
+                                                                      DEFAULT_UPDATE_MODE);
 
     @Length(max = 255)
     String hostname;
@@ -84,4 +87,5 @@ public class ExecutorOptions {
 
     UserSpec defaultUserSpec;
 
+    RemoteUpdateMode remoteUpdateMode;
 }

--- a/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteNodeDataStore.java
+++ b/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteNodeDataStore.java
@@ -1,0 +1,89 @@
+package com.phonepe.drove.executor.discovery;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.phonepe.drove.common.discovery.NodeDataStore;
+import com.phonepe.drove.common.model.MessageDeliveryStatus;
+import com.phonepe.drove.common.model.MessageHeader;
+import com.phonepe.drove.common.model.controller.ExecutorSnapshotMessage;
+import com.phonepe.drove.executor.ExecutorOptions;
+import com.phonepe.drove.executor.engine.ExecutorCommunicator;
+import com.phonepe.drove.models.info.nodedata.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * This node data store is to be used by executors to send data to controller only. It is not supposed to
+ * store any data locally. Depending on config, it might route to either ZK or HTTP calls.
+ */
+@Slf4j
+@AllArgsConstructor(access = AccessLevel.PROTECTED, onConstructor_ = {@VisibleForTesting})
+public class RemoteNodeDataStore implements NodeDataStore {
+    private final RemoteUpdateMode remoteUpdateMode;
+    private final Provider<ExecutorCommunicator> communicator;
+    private final NodeDataStore remoteStore;
+
+    @Inject
+    public RemoteNodeDataStore(
+            ExecutorOptions executorOptions,
+            Provider<ExecutorCommunicator> communicator,
+            @Named("PersistentNodeDataStore") NodeDataStore remoteStore) {
+        this(Objects.requireNonNullElse(executorOptions.getRemoteUpdateMode(), RemoteUpdateMode.RPC),
+             communicator,
+             remoteStore);
+    }
+
+    @Override
+    public void updateNodeData(NodeData nodeData) {
+        val status = nodeData.accept(new NodeDataVisitor<Boolean>() {
+            @Override
+            public Boolean visit(ControllerNodeData controllerData) {
+                return null;
+            }
+
+            @Override
+            public Boolean visit(ExecutorNodeData executorData) {
+                try {
+                    switch (remoteUpdateMode) {
+                        case STORE -> {
+                            remoteStore.updateNodeData(executorData);
+                        }
+                        case RPC -> {
+                            val response =
+                                    communicator.get()
+                                            .send(new ExecutorSnapshotMessage(MessageHeader.controllerRequest(),
+                                                                              executorData));
+                            if (!response.getStatus().equals(MessageDeliveryStatus.ACCEPTED)) {
+                                log.warn("RPC based update failed. Reverting to store based state update.");
+                                remoteStore.updateNodeData(executorData);
+                            }
+                        }
+                    }
+                    return true;
+                }
+                catch (Throwable t) {
+                    log.error("Could not update node state: {}", t.getMessage(), t);
+                }
+                return false;
+            }
+        });
+        log.debug("Remote state update status: {}", status);
+    }
+
+    @Override
+    public List<NodeData> nodes(NodeType nodeType) {
+        return remoteStore.nodes(nodeType);
+    }
+
+    @Override
+    public void removeNodeData(NodeData nodeData) {
+        throw new UnsupportedOperationException("Not supported in remote mode");
+    }
+}

--- a/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteUpdateMode.java
+++ b/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteUpdateMode.java
@@ -1,9 +1,15 @@
 package com.phonepe.drove.executor.discovery;
 
 /**
- *
+ * Represents how executor will send updates to controller
  */
 public enum RemoteUpdateMode {
+    /**
+     * Direct store update
+     */
     STORE,
+    /**
+     * Send update over HTTP(S), in case of failure, send over store
+     */
     RPC
 }

--- a/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteUpdateMode.java
+++ b/drove-executor/src/main/java/com/phonepe/drove/executor/discovery/RemoteUpdateMode.java
@@ -1,0 +1,9 @@
+package com.phonepe.drove.executor.discovery;
+
+/**
+ *
+ */
+public enum RemoteUpdateMode {
+    STORE,
+    RPC
+}

--- a/drove-executor/src/test/java/com/phonepe/drove/executor/discovery/RemoteNodeDataStoreTest.java
+++ b/drove-executor/src/test/java/com/phonepe/drove/executor/discovery/RemoteNodeDataStoreTest.java
@@ -1,0 +1,211 @@
+/*
+ *  Copyright (c) 2025 Original Author(s), PhonePe India Pvt. Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.phonepe.drove.executor.discovery;
+
+import com.phonepe.drove.common.discovery.NodeDataStore;
+import com.phonepe.drove.common.model.Message;
+import com.phonepe.drove.common.model.MessageDeliveryStatus;
+import com.phonepe.drove.common.model.MessageResponse;
+import com.phonepe.drove.executor.ExecutorOptions;
+import com.phonepe.drove.executor.engine.ExecutorCommunicator;
+import com.phonepe.drove.models.info.nodedata.*;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests {@link RemoteNodeDataStore}
+ */
+class RemoteNodeDataStoreTest {
+
+    @Test
+    void testRpcSendSuccess() {
+        val communicatorCalled = new AtomicBoolean(false);
+        val upstreamCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(ExecutorOptions.DEFAULT,
+                                          () -> communicator,
+                                          upstream);
+        when(communicator.send(any()))
+                .thenAnswer(invocationMock -> {
+                    val message = invocationMock.getArgument(0, Message.class);
+                    communicatorCalled.set(true);
+                    return new MessageResponse(message.getHeader(), MessageDeliveryStatus.ACCEPTED);
+                });
+        doAnswer(invocationOnMock -> {
+            upstreamCalled.set(true);
+            return null;
+        }).when(upstream).updateNodeData(any(NodeData.class));
+        val data = generateDummyData();
+        nds.updateNodeData(data);
+        assertTrue(communicatorCalled.get());
+        assertFalse(upstreamCalled.get());
+    }
+
+    @Test
+    void testUpstreamSendSuccess() {
+        val communicatorCalled = new AtomicBoolean(false);
+        val upstreamCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(ExecutorOptions.DEFAULT
+                                                  .withRemoteUpdateMode(RemoteUpdateMode.STORE),
+                                          () -> communicator,
+                                          upstream);
+        when(communicator.send(any()))
+                .thenAnswer(invocationMock -> {
+                    val message = invocationMock.getArgument(0, Message.class);
+                    communicatorCalled.set(true);
+                    return new MessageResponse(message.getHeader(), MessageDeliveryStatus.ACCEPTED);
+                });
+        doAnswer(invocationOnMock -> {
+            upstreamCalled.set(true);
+            return null;
+        }).when(upstream).updateNodeData(any(NodeData.class));
+        val data = generateDummyData();
+        nds.updateNodeData(data);
+        assertFalse(communicatorCalled.get());
+        assertTrue(upstreamCalled.get());
+    }
+
+    @Test
+    void testUpstreamFallbackOnFailure() {
+        val communicatorCalled = new AtomicBoolean(false);
+        val upstreamCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(ExecutorOptions.DEFAULT.withRemoteUpdateMode(null), //Default to RPC
+                                          () -> communicator,
+                                          upstream);
+        when(communicator.send(any()))
+                .thenAnswer(invocationMock -> {
+                    val message = invocationMock.getArgument(0, Message.class);
+                    communicatorCalled.set(true);
+                    return new MessageResponse(message.getHeader(), MessageDeliveryStatus.FAILED);
+                });
+        doAnswer(invocationOnMock -> {
+            upstreamCalled.set(true);
+            return null;
+        }).when(upstream).updateNodeData(any(NodeData.class));
+        val data = generateDummyData();
+        nds.updateNodeData(data);
+        assertTrue(communicatorCalled.get());
+        assertTrue(upstreamCalled.get());
+    }
+
+    @Test
+    void testUpstreamFallbackOnError() {
+        val communicatorCalled = new AtomicBoolean(false);
+        val upstreamCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(RemoteUpdateMode.RPC,
+                                          () -> communicator,
+                                          upstream);
+        when(communicator.send(any()))
+                .thenAnswer(invocationMock -> {
+                    communicatorCalled.set(true);
+                    throw new IllegalStateException("Simulated comms error");
+                });
+        doAnswer(invocationOnMock -> {
+            upstreamCalled.set(true);
+            return null;
+        }).when(upstream).updateNodeData(any(NodeData.class));
+        val data = generateDummyData();
+        nds.updateNodeData(data);
+        assertTrue(communicatorCalled.get());
+        assertTrue(upstreamCalled.get());
+    }
+
+    @Test
+    void testFailure() {
+        val communicatorCalled = new AtomicBoolean(false);
+        val upstreamCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(RemoteUpdateMode.RPC,
+                                          () -> communicator,
+                                          upstream);
+        when(communicator.send(any()))
+                .thenAnswer(invocationMock -> {
+                    communicatorCalled.set(true);
+                    throw new IllegalStateException("Simulated comms error");
+                });
+        doAnswer(invocationOnMock -> {
+            upstreamCalled.set(true);
+            throw new IllegalStateException("Update failure");
+        }).when(upstream).updateNodeData(any(NodeData.class));
+        val data = generateDummyData();
+        nds.updateNodeData(data);
+        assertTrue(communicatorCalled.get());
+        assertTrue(upstreamCalled.get());
+    }
+
+    @Test
+    void testIllegalOps() {
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(RemoteUpdateMode.RPC,
+                                          () -> communicator,
+                                          upstream);
+        assertThrows(IllegalArgumentException.class,
+                     () -> nds.updateNodeData(new ControllerNodeData(null, 0, null, null, false)));
+        assertThrows(UnsupportedOperationException.class,
+                     () -> nds.removeNodeData(null));
+    }
+
+    @Test
+    void testNodePassthrough() {
+        val nodesCalled = new AtomicBoolean(false);
+        val communicator = mock(ExecutorCommunicator.class);
+        val upstream = mock(NodeDataStore.class);
+        val nds = new RemoteNodeDataStore(RemoteUpdateMode.RPC,
+                                          () -> communicator,
+                                          upstream);
+        when(upstream.nodes(any()))
+                .thenAnswer(invocationOnMock -> {
+                    nodesCalled.set(true);
+                    return List.of();
+                });
+        assertTrue(nds.nodes(NodeType.CONTROLLER).isEmpty());
+        assertTrue(nodesCalled.get());
+    }
+
+    private static ExecutorNodeData generateDummyData() {
+        return new ExecutorNodeData("localhost",
+                                    8080,
+                                    NodeTransportType.HTTP,
+                                    new Date(),
+                                    null,
+                                    List.of(),
+                                    List.of(),
+                                    List.of(),
+                                    Set.of(),
+                                    Map.of(),
+                                    ExecutorState.ACTIVE);
+    }
+}


### PR DESCRIPTION
Right now, all executors send updates to ZK. With clusters having many nodes or running many containers that are constantly in a state of flux, this creates a lot of write pressure on zk. This PR addresses this issue by implementing a `RemoteNodeDataStore` implementation in the executor with the following behaviour:
- Implement a new config option called `remoteUpdateMode` in `ExecutorOptions` that can be set to `STORE` or `RPC` (default)
- `STORE` is the legacy behaviour and it will lead the executor to send updates via ZK
- `RPC` mode (the default behaviour going forward) will lead to updates being sent over HTTP to the leader controller via the existing `communicator`. In case update fails or there is an exception in the update path, updates will be sent via the store (ZK)

Calls to `removeNodes` will lead to an error and calls to `nodes` will be routed via ZK.

The Guice Module has been updated to create appropriate objects. 